### PR TITLE
fix: correct link to agent-skills repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Neon AI Rules - Project Documentation
 
+> **Note**: This repository has been archived. Content has moved to [neondatabase/agent-skills](https://github.com/neondatabase/agent-skills).
+
 ## Project Overview
 
 This repository contains a comprehensive suite of AI-powered development tools for Neon, including:
@@ -37,10 +39,14 @@ The primary audience includes AI developers using Claude, Cursor, and other AI-p
 │       │   └── templates/         # Client templates
 │       ├── neon-serverless/
 │       └── neon-toolkit/
-├── references/                    # Shared technical reference docs
+├── references/                    # Shared technical reference docs (16 files)
 │   ├── code-generation-rules.md
-│   ├── neon-auth-*.md             # Auth-related references
-│   └── neon-js-*.md               # Neon JS references
+│   ├── neon-auth-*.md             # Auth-related references (11 files)
+│   │   # Includes: common-mistakes, components, provider-config,
+│   │   # setup (general, nextjs, nodejs, react-spa), troubleshooting,
+│   │   # ui (general, nextjs, react-spa)
+│   └── neon-js-*.md               # Neon JS references (4 files)
+│       # Includes: adapters, data-api, imports, theming
 ├── mcp-prompts/                   # MCP prompt templates
 ├── .claude/
 │   └── settings.local.json        # Local Claude Code settings
@@ -172,6 +178,11 @@ Each skill is self-contained with multiple components:
 - Keep plugin.json version in sync with major updates
 
 ## Recent Changes & Decisions
+
+### Repository Archived (January 2026)
+- Repository archived; content moved to [neondatabase/agent-skills](https://github.com/neondatabase/agent-skills)
+- New repository follows Agent Skills specification supported by major agents and editors
+- Install via: `npx skills add neondatabase/agent-skills`
 
 ### Version 1.1.0 Release (December 9, 2025)
 - Added **neon-auth** skill for Neon Auth integration with `@neondatabase/auth`

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 </picture>
 
 > [!IMPORTANT]
-> **This repository has been archived.** The content has moved to [neondatabase/agent-rules](https://github.com/neondatabase/agent-rules).
+> **This repository has been archived.** The content has moved to [neondatabase/agent-skills](https://github.com/neondatabase/agent-skills).
 >
 > [Agent Skills](https://neon.com/blog/agent-skills-in-2026) are now a specification supported by all major agents and coding editors, providing more capabilities than rule files. We created a new repository following the agent-skills pattern introduced by Vercel.
 >
 > ```bash
-> npx skills add neondatabase/agent-rules
+> npx skills add neondatabase/agent-skills
 > ```
 
 # Neon AI Development Toolkit
@@ -185,7 +185,7 @@ Our skills are tested with automated evaluations to ensure reliability and quali
 ## Context Rules (.mdc Files)
 
 <details>
-<summary><strong>Getting Started</strong> - 1 file</summary>
+<summary><strong>Getting Started</strong> - 2 files</summary>
 
 **Neon Get Started** (`neon-get-started.mdc`)
 
@@ -194,14 +194,22 @@ Our skills are tested with automated evaluations to ensure reliability and quali
 - Works with new or existing codebases
 - Communication style guidelines for AI assistants
 
+**Neon Get Started (Kiro)** (`neon-get-started-kiro.mdc`)
+
+- Kiro-specific onboarding guide
+
 </details>
 
 <details>
-<summary><strong>Core Integration Rules</strong> - 4 files</summary>
+<summary><strong>Core Integration Rules</strong> - 5 files</summary>
 
 **Neon Auth** (`neon-auth.mdc`)
 - Stack Auth + Neon Auth integration
 - Authentication patterns for user data
+
+**Neon JS** (`neon-js.mdc`)
+- Full Neon JS SDK with `@neondatabase/neon-js`
+- Combined auth + data API client
 
 **Neon Serverless** (`neon-serverless.mdc`)
 - Serverless connection patterns


### PR DESCRIPTION
## Description

This PR fixes the incorrect repository link in the archive notice. The link was pointing to `neondatabase/agent-rules` but should be `neondatabase/agent-skills`.

**FIXES**
- Correct archived repository link from `agent-rules` to `agent-skills` in README.md
- Update `npx skills add` command to use correct repository name
- Add archive notice to CLAUDE.md with correct repository link
- Improve directory structure documentation in CLAUDE.md with file counts and detailed comments

## Test Plan

- [x] Verify all links point to the correct repository: `neondatabase/agent-skills`
- [x] Verify `npx skills add neondatabase/agent-skills` command is correct